### PR TITLE
Add initial stream to session.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,10 @@ function MediaSession(opts) {
     this.pc.on('addStream', this.onAddStream.bind(this));
     this.pc.on('removeStream', this.onRemoveStream.bind(this));
 
+    if (opts.stream) {
+        this.addStream(opts.stream);
+    }
+
     this._ringing = false;
 }
 


### PR DESCRIPTION
If options passed to constructor contains an initial stream, add it to the session immediately. Otherwise the `stream` property of options passed to the constructor in jingle.js on [L152](https://github.com/otalk/jingle.js/blob/master/index.js#L152) is ignored and the stream isn't added.
