### PR TITLE
Emit an event for the connection state change

### DIFF
--- a/index.js
+++ b/index.js
@@ -346,6 +346,7 @@ MediaSession.prototype = extend(MediaSession.prototype, {
                 this.connectionState = 'disconnected';
                 break;
         }
+        this.emit('connectionStateChange', this, this.connectionState);
     },
 
     // ----------------------------------------------------------------


### PR DESCRIPTION
It makes sense to emit an event for the ice connection state change. Consumers might show connection state indicators for visual feedback on the peer connection, and this would facilitate that.
