### PR TITLE
use initial constraints for createOffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,8 @@ function MediaSession(opts) {
         useJingle: true
     }, opts.constraints || {});
 
+    this._constraints = opts.constraints;
+
     this.pc.on('ice', this.onIceCandidate.bind(this));
     this.pc.on('iceConnectionStateChange', this.onIceStateChange.bind(this));
     this.pc.on('addStream', this.onAddStream.bind(this));
@@ -82,6 +84,7 @@ MediaSession.prototype = extend(MediaSession.prototype, {
         var self = this;
         this.state = 'pending';
 
+        constraints = constraints || this._constraints;
         next = next || function () {};
 
         this.pc.isInitiator = true;


### PR DESCRIPTION
The passed constraint option to MediaSession, does not have any effect if you start a session, because  [RTCPeerConnection](https://github.com/otalk/RTCPeerConnection/) will [overwrite](https://github.com/otalk/RTCPeerConnection/blob/master/rtcpeerconnection.js#L305) it if you do not pass constraints so <code>MediaSession.start()</code>.

This is only a simplification and comes in handy if you want to satisfy firefox with its warning about deprecated mandatory/optional options.
