### PR TITLE
bump rtcpeerconnection to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "extend-object": "^1.0.0",
     "jingle-session": "^1.0.0",
-    "rtcpeerconnection": "^3.1.6"
+    "rtcpeerconnection": "^4.0.0"
   },
   "devDependencies": {
     "browserify": "^5.11.1",


### PR DESCRIPTION
getStats was the only change in 4.0.0 so this should go easily. Not sure if this is a major/minor bump in jingle.js... @legastero @xdumaine?
