### PR TITLE
Properly handle renego for initiator-side stream changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,31 +239,59 @@ MediaSession.prototype = extend(MediaSession.prototype, {
             self.constraints = renegotiate;
         }
 
-        this.pc.handleOffer({
-            type: 'offer',
-            jingle: this.pc.remoteDescription
-        }, function (err) {
-            if (err) {
-                self._log('error', 'Could not create offer for adding new stream');
-                return cb(err);
-            }
-            self.pc.answer(self.constraints, function (err, answer) {
+        if (this.pc.isInitiator) {
+            this.pc.offer(self.constraints, function (err, offer) {
                 if (err) {
-                    self._log('error', 'Could not create answer for adding new stream');
+                    self._log('error', 'Could not create offer for adding new stream');
                     return cb(err);
                 }
-                answer.jingle.contents.forEach(function (content) {
-                    filterContentSources(content, stream);
-                });
-                answer.jingle.contents = answer.jingle.contents.filter(function (content) {
-                    return content.application.applicationType === 'rtp' && content.application.sources && content.application.sources.length;
-                });
-                delete answer.jingle.groups;
+                self.pc.handleAnswer({
+                    type: 'answer',
+                    jingle: self.pc.remoteDescription
+                }, function (err) {
+                    if (err) {
+                        self._log('error', 'Could not process answer for adding new stream');
+                        return cb(err);
+                    }
+                    offer.jingle.contents.forEach(function (content) {
+                        filterContentSources(content, stream);
+                    });
+                    offer.jingle.contents = offer.jingle.contents.filter(function (content) {
+                        return content.application.applicationType === 'rtp' && content.application.sources && content.application.sources.length;
+                    });
+                    delete offer.jingle.groups;
 
-                self.send('source-add', answer.jingle);
-                cb();
+                    self.send('source-add', offer.jingle);
+                    cb();
+                });
             });
-        });
+        } else {
+            this.pc.handleOffer({
+                type: 'offer',
+                jingle: this.pc.remoteDescription
+            }, function (err) {
+                if (err) {
+                    self._log('error', 'Could not process offer for adding new stream');
+                    return cb(err);
+                }
+                self.pc.answer(self.constraints, function (err, answer) {
+                    if (err) {
+                        self._log('error', 'Could not create answer for adding new stream');
+                        return cb(err);
+                    }
+                    answer.jingle.contents.forEach(function (content) {
+                        filterContentSources(content, stream);
+                    });
+                    answer.jingle.contents = answer.jingle.contents.filter(function (content) {
+                        return content.application.applicationType === 'rtp' && content.application.sources && content.application.sources.length;
+                    });
+                    delete answer.jingle.groups;
+
+                    self.send('source-add', answer.jingle);
+                    cb();
+                });
+            });
+        }
     },
 
     addStream2: function (stream, cb) {
@@ -294,22 +322,41 @@ MediaSession.prototype = extend(MediaSession.prototype, {
         this.send('source-remove', desc);
         this.pc.removeStream(stream);
 
-        this.pc.handleOffer({
-            type: 'offer',
-            jingle: this.pc.remoteDescription
-        }, function (err) {
-            if (err) {
-                self._log('error', 'Could not process offer for removing stream');
-                return cb(err);
-            }
-            self.pc.answer(self.constraints, function (err) {
+        if (this.pc.isInitiator) {
+            this.pc.offer(self.constraints, function (err) {
                 if (err) {
-                    self._log('error', 'Could not process answer for removing stream');
+                    self._log('error', 'Could not create offer for removing stream');
                     return cb(err);
                 }
-                cb();
+                self.pc.handleAnswer({
+                    type: 'answer',
+                    jingle: self.pc.remoteDescription
+                }, function (err) {
+                    if (err) {
+                        self._log('error', 'Could not process answer for removing stream');
+                        return cb(err);
+                    }
+                    cb();
+                });
             });
-        });
+        } else {
+            this.pc.handleOffer({
+                type: 'offer',
+                jingle: this.pc.remoteDescription
+            }, function (err) {
+                if (err) {
+                    self._log('error', 'Could not process offer for removing stream');
+                    return cb(err);
+                }
+                self.pc.answer(self.constraints, function (err) {
+                    if (err) {
+                        self._log('error', 'Could not create answer for removing stream');
+                        return cb(err);
+                    }
+                    cb();
+                });
+            });
+        }
     },
 
     removeStream2: function (stream, cb) {
@@ -330,28 +377,51 @@ MediaSession.prototype = extend(MediaSession.prototype, {
         this.pc.removeStream(oldStream);
         this.send('source-remove', desc);
 
-        this.pc.addStream(newStream);
-        this.pc.handleOffer({
-            type: 'offer',
-            jingle: this.pc.remoteDescription
-        }, function (err) {
-            if (err) {
-                self._log('error', 'Could not process offer for switching streams');
-                return cb(err);
-            }
-            self.pc.answer(self.constraints, function (err, answer) {
+        if (this.pc.isInitiator) {
+            this.pc.offer(self.constraints, function (err, offer) {
                 if (err) {
-                    self._log('error', 'Could not process answer for switching streams');
+                    self._log('error', 'Could not create offer for switching streams');
                     return cb(err);
                 }
-                answer.jingle.contents.forEach(function (content) {
+                offer.jingle.contents.forEach(function (content) {
                     delete content.transport;
                     delete content.application.payloads;
                 });
-                self.send('source-add', answer.jingle);
-                cb();
+                self.pc.handleAnswer({
+                    type: 'answer',
+                    jingle: self.pc.remoteDescription
+                }, function (err) {
+                    if (err) {
+                        self._log('error', 'Could not process answer for switching streams');
+                        return cb(err);
+                    }
+                    self.send('source-add', offer.jingle);
+                    cb();
+                });
             });
-        });
+        } else {
+            this.pc.handleOffer({
+                type: 'offer',
+                jingle: this.pc.remoteDescription
+            }, function (err) {
+                if (err) {
+                    self._log('error', 'Could not process offer for switching streams');
+                    return cb(err);
+                }
+                self.pc.answer(self.constraints, function (err, answer) {
+                    if (err) {
+                        self._log('error', 'Could not create answer for switching streams');
+                        return cb(err);
+                    }
+                    answer.jingle.contents.forEach(function (content) {
+                        delete content.transport;
+                        delete content.application.payloads;
+                    });
+                    self.send('source-add', answer.jingle);
+                    cb();
+                });
+            });
+        }
     },
 
     // ----------------------------------------------------------------
@@ -541,27 +611,50 @@ MediaSession.prototype = extend(MediaSession.prototype, {
             });
         });
 
-        this.pc.handleOffer({
-            type: 'offer',
-            jingle: newDesc
-        }, function (err) {
-            if (err) {
-                self._log('error', 'Error adding new stream source');
-                return cb({
-                    condition: 'general-error'
-                });
-            }
-
-            self.pc.answer(self.constraints, function (err) {
+        if (this.pc.isInitiator) {
+            this.pc.offer(this.constraints, function (err) {
                 if (err) {
                     self._log('error', 'Error adding new stream source');
                     return cb({
                         condition: 'general-error'
                     });
                 }
-                cb();
+                self.pc.handleAnswer({
+                    type: 'answer',
+                    jingle: newDesc
+                }, function (err) {
+                    if (err) {
+                        self._log('error', 'Error adding new stream source');
+                        return cb({
+                            condition: 'general-error'
+                        });
+                    }
+                    cb();
+                });
             });
-        });
+        } else {
+            this.pc.handleOffer({
+                type: 'offer',
+                jingle: newDesc
+            }, function (err) {
+                if (err) {
+                    self._log('error', 'Error adding new stream source');
+                    return cb({
+                        condition: 'general-error'
+                    });
+                }
+
+                self.pc.answer(self.constraints, function (err) {
+                    if (err) {
+                        self._log('error', 'Error adding new stream source');
+                        return cb({
+                            condition: 'general-error'
+                        });
+                    }
+                    cb();
+                });
+            });
+        }
     },
 
     onSourceRemove: function (changes, cb) {
@@ -627,26 +720,49 @@ MediaSession.prototype = extend(MediaSession.prototype, {
             });
         });
 
-        this.pc.handleOffer({
-            type: 'offer',
-            jingle: newDesc
-        }, function (err) {
-            if (err) {
-                self._log('error', 'Error removing stream source');
-                return cb({
-                    condition: 'general-error'
-                });
-            }
-            self.pc.answer(self.constraints, function (err) {
+        if (this.pc.isInitiator) {
+            this.pc.offer(this.constraints, function (err) {
                 if (err) {
                     self._log('error', 'Error removing stream source');
                     return cb({
                         condition: 'general-error'
                     });
                 }
-                cb();
+                self.pc.handleAnswer({
+                    type: 'answer',
+                    jingle: newDesc
+                }, function (err) {
+                    if (err) {
+                        self._log('error', 'Error removing stream source');
+                        return cb({
+                            condition: 'general-error'
+                        });
+                    }
+                    cb();
+                });
             });
-        });
+        } else {
+            this.pc.handleOffer({
+                type: 'offer',
+                jingle: newDesc
+            }, function (err) {
+                if (err) {
+                    self._log('error', 'Error removing stream source');
+                    return cb({
+                        condition: 'general-error'
+                    });
+                }
+                self.pc.answer(self.constraints, function (err) {
+                    if (err) {
+                        self._log('error', 'Error removing stream source');
+                        return cb({
+                            condition: 'general-error'
+                        });
+                    }
+                    cb();
+                });
+            });
+        }
     },
 
     // ----------------------------------------------------------------


### PR DESCRIPTION
@fippo @legastero @latentflip This should resolve this bug that I opened last year. When I opened that, I didn't fully understand jsep and offer/answer. This basically allows on the fly stream changes for 1:1 jingle sessions. It's never been a problem before since most users of this who are doing stream changes are connected an SFU (jitsi) and are never the initiator. In my case, I'm allowing stream changes (i.e., adding screen, switching device stream) during 1:1s, which fails because the assumption is always made that when making or processing stream changes, you're the answerer.

tldr: check `isInitiator` and flip the offer/answer to make stream renegos work for initiator side.

 https://github.com/otalk/jingle.js/issues/24 
