### PR TITLE
Return MediaSession during ringing

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ Object.defineProperties(MediaSession.prototype, {
         set: function (value) {
             if (value !== this._ringing) {
                 this._ringing = value;
-                this.emit('change:ringing', value);
+                this.emit('change:ringing', this, value);
             }
         }
     },


### PR DESCRIPTION
As `jingle` emitting like below:
```
        self.emit(name, data, extraData, extraData2);
```

So the `data` part should be `MediaSession` as everywhere else its being used that way.