### PR TITLE
Fix error when no contents are in the source-add message

### DIFF
--- a/index.js
+++ b/index.js
@@ -524,7 +524,7 @@ MediaSession.prototype = extend(MediaSession.prototype, {
             var ssrcs = desc.sources || [];
             var groups = desc.sourceGroups || [];
 
-            changes.contents.forEach(function (newContent) {
+            changes.contents && changes.contents.forEach(function (newContent) {
                 if (content.name !== newContent.name) {
                     return;
                 }


### PR DESCRIPTION
I was seeing an error that forEach isn't defined with a source-add message that didn't have contents which caused later source-add messages to not be processed. 