### PR TITLE
Add check for parameters array with missing elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ function filterContentSources(content, stream) {
 
     if (content.application.sources) {
         content.application.sources = content.application.sources.filter(function (source) {
+            // if there's no msid, ignore it
+            if (source.parameters.length < 2) {
+              return false;
+            }
             return stream.id === source.parameters[1].value.split(' ')[0];
         });
     }


### PR DESCRIPTION
I saw an issue where a `source.parameters` array can be passed in which has only one element. When the library tries accessing its second element, it causes an error. By making it more resilient, subsequent well-formed calls can still be processed.